### PR TITLE
chore(deps): updated rand to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -775,6 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +941,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1014,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1166,7 +1209,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1283,6 +1326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,7 +1393,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1424,6 +1473,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1678,7 +1733,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -1925,6 +1980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,7 +2033,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2005,7 +2070,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2047,6 +2112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2159,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redox_syscall"
@@ -2549,7 +2631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3129,6 +3211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unwrap-infallible"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e497bb1f828cc9fb236722c2eaa100dcf201563f38f4da6252357a59037adf31"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,7 +3280,25 @@ version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.45.0",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3267,6 +3373,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wazuh-cert-oauth2-client"
 version = "0.4.2"
 dependencies = [
@@ -3277,7 +3417,7 @@ dependencies = [
  "mid",
  "oauth2",
  "openssl",
- "rand 0.9.2",
+ "rand 0.10.0",
  "tokio",
  "wazuh-cert-oauth2-model",
 ]
@@ -3302,7 +3442,8 @@ dependencies = [
  "jsonwebtoken",
  "oauth2",
  "openssl",
- "rand_core 0.9.5",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
  "reqwest",
  "rocket",
  "serde",
@@ -3323,7 +3464,7 @@ dependencies = [
  "mimalloc",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rocket",
  "serde",
  "tokio",
@@ -3340,12 +3481,13 @@ dependencies = [
  "clap",
  "mimalloc",
  "oauth2",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rocket",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "unwrap-infallible",
  "wazuh-cert-oauth2-model",
 ]
 
@@ -3688,6 +3830,94 @@ name = "wit-bindgen"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 log = { version = "0.4", features = ["std"] }
 env_logger = "0"
 openssl = { version = "0"}
-rand = "0.9"
-rand_core = "0.9.5"
+rand = "0.10.0"
+rand_core = "0.10.0"
 rocket = { version = "0", features = ["tls", "json", "mtls", "serde_json"] }
 diacritics = "0"
 mid = "4"
@@ -31,9 +31,10 @@ oauth2 = { version = "5", features = ["reqwest"] }
 clap = { version = "4", features = ["derive", "env"] }
 base64 = "0.22"
 url = "2"
+unwrap-infallible = "1.0.0"
 
 openssl-sys = "0"
-foreign-types = "0"
+foreign-types = "0.3.2"
 
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing = { version = "0", features = ["attributes", "async-await", "std"] }

--- a/crates/wazuh-cert-oauth2-model/Cargo.toml
+++ b/crates/wazuh-cert-oauth2-model/Cargo.toml
@@ -19,6 +19,7 @@ oauth2.workspace = true
 clap.workspace = true
 url.workspace = true
 rand_core.workspace = true
+rand.workspace = true
 
 [dependencies.tracing-subscriber]
 workspace = true

--- a/crates/wazuh-cert-oauth2-model/src/models/errors.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/errors.rs
@@ -94,7 +94,7 @@ pub enum AppError {
     //#[error("Random generation error: {0}")]
     //RandOsError(#[from] rand_core::Error),
     #[error("Rand OS generation error: {0}")]
-    RandOsError(#[from] rand_core::OsError),
+    RandOsError(#[from] rand::rngs::SysError),
 
     #[cfg(feature = "rocket")]
     #[error("SetGlobalDefaultError error: {source}")]

--- a/crates/wazuh-cert-oauth2-server/src/shared/certs/build_base.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/certs/build_base.rs
@@ -6,8 +6,8 @@ use openssl::nid::Nid;
 use openssl::pkey::Id as PKeyId;
 use openssl::pkey::PKey;
 use openssl::x509::{X509NameBuilder, X509Ref, X509Req};
-use rand::TryRngCore;
-use rand::rngs::OsRng;
+use rand::TryRng;
+use rand::rngs::SysRng;
 use wazuh_cert_oauth2_model::models::errors::AppResult;
 
 pub(crate) fn set_subject_cn(name_builder: &mut X509NameBuilder, cn: &str) -> AppResult<()> {
@@ -33,7 +33,7 @@ pub(crate) fn set_subject_and_pubkey(
 
 pub(crate) fn set_serial_number(builder: &mut openssl::x509::X509Builder) -> AppResult<()> {
     let mut serial = [0u8; 16];
-    OsRng.try_fill_bytes(&mut serial)?;
+    SysRng.try_fill_bytes(&mut serial)?;
     serial[0] &= 0x7F;
     if serial.iter().all(|&b| b == 0) {
         serial[0] = 1;

--- a/crates/wazuh-cert-oauth2-webhook/Cargo.toml
+++ b/crates/wazuh-cert-oauth2-webhook/Cargo.toml
@@ -17,6 +17,7 @@ oauth2.workspace = true
 mimalloc.workspace = true
 rand.workspace = true
 base64.workspace = true
+unwrap-infallible.workspace = true
 
 [dependencies.wazuh-cert-oauth2-model]
 workspace = true

--- a/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rand::Rng;
+use rand::TryRng;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
+use unwrap_infallible::UnwrapInfallible;
 use wazuh_cert_oauth2_model::models::errors::AppResult;
 use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
 
@@ -71,7 +72,7 @@ pub async fn queue_revoke_to_spool_dir(state: &ProxyState, req: RevokeRequest) -
         .unwrap_or_default()
         .as_millis();
     let mut buf = [0u8; 8];
-    rand::rng().fill(&mut buf);
+    rand::rng().try_fill_bytes(&mut buf).unwrap_infallible();
     let mut rid = String::with_capacity(buf.len() * 2);
     for b in buf {
         rid.push_str(&format!("{:02x}", b));


### PR DESCRIPTION
## Summary

Updates `rand` and `rand_core` from `0.9` to `0.10`, adapting the codebase to its breaking API changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD or tooling

## Changes Made

- Bumped `rand` to `0.10.0` and `rand_core` to `0.10.0` in workspace `Cargo.toml`
- Replaced `rand_core::OsError` → `rand::rngs::SysError` in `AppError`
- Replaced `rand::TryRngCore` + `OsRng` → `rand::TryRng` + `SysRng` in `build_base.rs`
- Replaced `rand::Rng::fill` → `TryRng::try_fill_bytes().unwrap_infallible()` in `spool.rs`
- Added `unwrap-infallible` as a workspace dependency
- Pinned `foreign-types` to `0.3.2` to resolve a transitive compatibility issue
- Added `rand` as a direct dependency to `wazuh-cert-oauth2-model` (previously only `rand_core` was listed)
> See https://rust-random.github.io/book/update-0.10.html

## Checklist

- [x] Code follows the project's style (`cargo fmt`)
- [x] Self-review completed
- [ ] Tests added/updated for changes
- [x] All tests pass (`cargo test`)
- [x] No new clippy warnings (`cargo clippy -- -D warnings`)
- [ ] Documentation updated if needed

## Security Considerations

Does this PR have security implications? (authentication, certificates, cryptography, etc.)

- [x] No security impact
- [ ] Security impact reviewed (describe below)

## Testing

How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing with `docker compose`
- [x] Other:
