### PR TITLE
Feat/client migrate from oob

### DIFF
--- a/.docker/keycloak_config/realm.json
+++ b/.docker/keycloak_config/realm.json
@@ -51,8 +51,8 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "urn:ietf:wg:oauth:2.0:oob",
-        "*"
+        "http://localhost:*",
+        "http://127.0.0.1:*"
       ],
       "webOrigins": [
         "*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2056,7 +2056,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2093,9 +2093,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2450,7 +2450,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3456,6 +3456,7 @@ dependencies = [
 name = "wazuh-cert-oauth2-client"
 version = "0.4.2"
 dependencies = [
+ "anyhow",
  "clap",
  "diacritics",
  "env_logger",
@@ -3465,6 +3466,7 @@ dependencies = [
  "openssl",
  "rand 0.10.0",
  "tokio",
+ "url",
  "wazuh-cert-oauth2-model",
 ]
 

--- a/crates/wazuh-cert-oauth2-client/Cargo.toml
+++ b/crates/wazuh-cert-oauth2-client/Cargo.toml
@@ -16,6 +16,8 @@ mid.workspace = true
 rand.workspace = true
 diacritics.workspace = true
 openssl.workspace = true
+anyhow.workspace = true
+url.workspace = true
 
 [dependencies.wazuh-cert-oauth2-model]
 features = ["openssl"]

--- a/crates/wazuh-cert-oauth2-client/src/flow.rs
+++ b/crates/wazuh-cert-oauth2-client/src/flow.rs
@@ -24,6 +24,7 @@ pub struct FlowParams {
     ca_cert_path: String,
     key_path: String,
     agent_control: bool,
+    timeout_secs: u64,
 }
 
 impl From<Opt> for FlowParams {
@@ -40,6 +41,7 @@ impl From<Opt> for FlowParams {
                 ca_cert_path,
                 key_path,
                 agent_control,
+                timeout_secs,
             } => Self {
                 issuer,
                 audience_csv: audience,
@@ -51,6 +53,7 @@ impl From<Opt> for FlowParams {
                 key_path,
                 agent_control,
                 ca_cert_path,
+                timeout_secs,
             },
         }
     }
@@ -84,6 +87,7 @@ pub async fn run_oauth2_flow(params: &FlowParams) -> AppResult<()> {
             client_id: params.client_id.clone(),
             client_secret: params.client_secret.clone(),
             is_service_account: params.is_service_account,
+            timeout_secs: params.timeout_secs,
         },
     )
     .await?;
@@ -144,6 +148,7 @@ mod tests {
             ca_cert_path: "/tmp/ca.pem".to_string(),
             key_path: "/tmp/client.key".to_string(),
             agent_control: false,
+            timeout_secs: 120,
         };
 
         let params = FlowParams::from(opt);

--- a/crates/wazuh-cert-oauth2-client/src/services/get_token.rs
+++ b/crates/wazuh-cert-oauth2-client/src/services/get_token.rs
@@ -4,6 +4,9 @@ use oauth2::{
     RedirectUrl, TokenResponse, TokenUrl,
 };
 use std::process::Command;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::oneshot;
+use url::Url;
 use wazuh_cert_oauth2_model::models::document::DiscoveryDocument;
 use wazuh_cert_oauth2_model::models::errors::AppResult;
 use wazuh_cert_oauth2_model::services::http_client::HttpClient;
@@ -15,6 +18,7 @@ pub struct GetTokenParams {
     pub client_id: String,
     pub client_secret: Option<String>,
     pub is_service_account: bool,
+    pub timeout_secs: u64,
 }
 
 /// Get a token from the OAuth2 server.
@@ -26,14 +30,9 @@ pub async fn get_token(http: &HttpClient, params: GetTokenParams) -> AppResult<S
         basic_client = basic_client.set_client_secret(secret)
     }
 
-    let client = if params.is_service_account {
-        basic_client.set_auth_type(AuthType::BasicAuth)
-    } else {
-        basic_client.set_redirect_uri(RedirectUrl::new("urn:ietf:wg:oauth:2.0:oob".to_string())?)
-    };
-
     if params.is_service_account {
-        let token_result = client
+        let token_result = basic_client
+            .set_auth_type(AuthType::BasicAuth)
             .exchange_client_credentials()?
             .request_async(http.client())
             .await?;
@@ -41,13 +40,79 @@ pub async fn get_token(http: &HttpClient, params: GetTokenParams) -> AppResult<S
         return Ok(token_result.access_token().secret().clone());
     }
 
+    // Bind the listener directly to avoid race conditions
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    debug!("Local callback server listening on port {}", port);
+
+    let client = basic_client.set_redirect_uri(RedirectUrl::new(format!(
+        "http://localhost:{}/callback",
+        port
+    ))?);
+
+    // Generate PKCE pair
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
-    let (auth_url, _csrf_token) = client
+
+    // Generate authorization URL with PKCE and CSRF
+    let (auth_url, csrf_token) = client
         .authorize_url(CsrfToken::new_random)
         .set_pkce_challenge(pkce_challenge)
         .url();
+
+    // Create a channel to receive the auth code
+    let (tx, rx) = oneshot::channel::<String>();
+
+    let csrf_secret = csrf_token.secret().clone();
+    let server_handle = tokio::spawn(async move {
+        let mut tx = Some(tx);
+        while let Ok((mut stream, _)) = listener.accept().await {
+            // Buffer size increased to 4096 bytes
+            let mut buffer = [0; 4096];
+            match stream.read(&mut buffer).await {
+                Ok(n) if n > 0 => {
+                    let request = String::from_utf8_lossy(&buffer[..n]);
+                    let (code, state_valid) = parse_callback_request(&request, &csrf_secret);
+
+                    let (response, success) = if state_valid {
+                        if let Some(auth_code) = code {
+                            // Send code only if it's the first connection that provides it
+                            if let Some(tx) = tx.take() {
+                                let _ = tx.send(auth_code);
+                            }
+                            (
+                                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<h2>Auth complete - you can close this tab.</h2>",
+                                true,
+                            )
+                        } else {
+                            (
+                                "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<h2>Auth failed: Missing code parameter.</h2>",
+                                false,
+                            )
+                        }
+                    } else {
+                        (
+                            "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<h2>Auth failed: CSRF token mismatch or missing state.</h2>",
+                            false,
+                        )
+                    };
+
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    if success {
+                        // Successfully received code, exit server loop
+                        break;
+                    }
+                }
+                Ok(_) => {
+                    debug!("Connection closed by client before data was sent.");
+                }
+                Err(e) => {
+                    error!("Error reading from TCP stream: {}", e);
+                }
+            }
+        }
+    });
+
     let auth_url_string = auth_url.to_string();
-    // Try to open the URL in the default browser, but always print it as fallback.
     if !open_in_browser(&auth_url_string) {
         info!(
             "Please open this URL in your browser: {}\n",
@@ -57,16 +122,48 @@ pub async fn get_token(http: &HttpClient, params: GetTokenParams) -> AppResult<S
         info!("Opened your default browser to: {}\n", auth_url_string);
     }
 
-    let mut auth_code = String::new();
-    std::io::stdin().read_line(&mut auth_code)?;
-    let code = AuthorizationCode::new(auth_code.trim().to_string());
+    // Configurable timeout (default 120s)
+    let timeout = params.timeout_secs;
+    let auth_code = match tokio::time::timeout(tokio::time::Duration::from_secs(timeout), rx).await
+    {
+        Ok(Ok(code)) => code,
+        Ok(Err(_)) => return Err(anyhow::anyhow!("Failed to receive authorization code").into()),
+        Err(_) => return Err(anyhow::anyhow!("Timeout waiting for authorization code").into()),
+    };
+
+    server_handle.abort();
+
     info!("Exchanging code for token...");
     let token_result = client
-        .exchange_code(code)?
+        .exchange_code(AuthorizationCode::new(auth_code))?
         .set_pkce_verifier(pkce_verifier)
         .request_async(http.client())
         .await?;
     Ok(token_result.access_token().secret().clone())
+}
+
+/// Parses the callback request to extract the code and validate the state.
+fn parse_callback_request(request: &str, expected_csrf_token: &str) -> (Option<String>, bool) {
+    let mut lines = request.lines();
+    let first_line = lines.next().unwrap_or("");
+    let mut parts = first_line.split_whitespace();
+    let _method = parts.next();
+    let path = parts.next().unwrap_or("");
+
+    let mut code = None;
+    let mut state_valid = false;
+
+    // Robust HTTP parsing using 'url' crate
+    if let Ok(url) = Url::parse(&format!("http://localhost{}", path)) {
+        for (k, v) in url.query_pairs() {
+            if k == "code" {
+                code = Some(v.into_owned());
+            } else if k == "state" && v == expected_csrf_token {
+                state_valid = true;
+            }
+        }
+    }
+    (code, state_valid)
 }
 
 /// Attempt to open a URL in the user's default browser.
@@ -131,4 +228,56 @@ fn open_in_browser(url: &str) -> bool {
     // Fallback for any other targets: do nothing.
     #[allow(unreachable_code)]
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_callback_request_success() {
+        let request =
+            "GET /callback?code=some_code&state=expected_state HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let expected_csrf = "expected_state";
+        let (code, state_valid) = parse_callback_request(request, expected_csrf);
+        assert_eq!(code, Some("some_code".to_string()));
+        assert!(state_valid);
+    }
+
+    #[test]
+    fn test_parse_callback_request_csrf_mismatch() {
+        let request =
+            "GET /callback?code=some_code&state=wrong_state HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let expected_csrf = "expected_state";
+        let (code, state_valid) = parse_callback_request(request, expected_csrf);
+        assert_eq!(code, Some("some_code".to_string()));
+        assert!(!state_valid);
+    }
+
+    #[test]
+    fn test_parse_callback_request_missing_code() {
+        let request = "GET /callback?state=expected_state HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let expected_csrf = "expected_state";
+        let (code, state_valid) = parse_callback_request(request, expected_csrf);
+        assert_eq!(code, None);
+        assert!(state_valid);
+    }
+
+    #[test]
+    fn test_parse_callback_request_malformed() {
+        let request = "not an http request";
+        let expected_csrf = "state";
+        let (code, state_valid) = parse_callback_request(request, expected_csrf);
+        assert_eq!(code, None);
+        assert!(!state_valid);
+    }
+
+    #[test]
+    fn test_parse_callback_request_with_fragment() {
+        let request = "GET /callback?code=some_code&state=expected_state#fragment HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let expected_csrf = "expected_state";
+        let (code, state_valid) = parse_callback_request(request, expected_csrf);
+        assert_eq!(code, Some("some_code".to_string()));
+        assert!(state_valid);
+    }
 }

--- a/crates/wazuh-cert-oauth2-client/src/shared/cli.rs
+++ b/crates/wazuh-cert-oauth2-client/src/shared/cli.rs
@@ -50,6 +50,9 @@ pub enum Opt {
 
         #[arg(env, long, default_value_t = true, action = ArgAction::Set, default_missing_value = "true", num_args = 0..=1)]
         agent_control: bool,
+
+        #[arg(env, long, default_value_t = 120, short = 't')]
+        timeout_secs: u64,
     },
 }
 


### PR DESCRIPTION
## Summary

Migrated the OAuth2 client from OOB (manual token entry) to a hardened local redirect server. This implements a more seamless flow for the user while strictly adhering to OAuth 2.0 security best practices (RFC 8252).

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [x] Security improvement

## Changes Made

- **Security Hardening**: 
    - Implemented **CSRF protection** by validating the `state` parameter in the callback.
    - Eliminated **port race conditions** by binding the TCP listener directly within the async flow.
- **Developer Experience & Tooling**:
    - Simplified channel handling in [get_token.rs](cci:7://file:///home/desmond/projects/Wazuh/wazuh-cert-oauth2/crates/wazuh-cert-oauth2-client/src/services/get_token.rs:0:0-0:0) by removing unnecessary `Arc<Mutex>` wrappers.
    - Added a configurable `--timeout-secs` (short: `-t`) flag to the CLI.
- **User Experience**:
    - The local server now returns explicit **HTML feedback** (Success/Error) to the user's browser after the callback.

## Checklist

- [x] Code follows the project's style (`cargo fmt`)
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] All tests pass (`cargo test`)
- [x] No new clippy warnings (`cargo clippy -- -D warnings`)
- [ ] Documentation updated if needed

## Security Considerations

- [x] Security impact reviewed
  - Added CSRF state validation to prevent authorization code injection.
  - Secured the local listener against port stealing during the handshake.
  - Implemented proper error handling for malformed or forged callback requests.

## Testing

- [x] Unit tests (Added 5 new tests specifically for the extraction and validation logic in [get_token.rs](https://github.com/ADORSYS-GIS/wazuh-cert-oauth2/commit/7046e8d47f130556fcede213fcd323d53868f543#diff-2c609a03e4422a04de11b1a59a01153f3662c57292002e7637208114b61409bdR233)
- [x] Manual testing (Verified with a local Keycloak instance and default browser redirection)

---