### PR TITLE
Feat/webhook improvements

### DIFF
--- a/.docker/keycloak_config/realm.json
+++ b/.docker/keycloak_config/realm.json
@@ -124,7 +124,7 @@
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
+      "serviceAccountsEnabled": true,
       "publicClient": false,
       "frontchannelLogout": true,
       "protocol": "openid-connect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,6 +3529,7 @@ dependencies = [
  "mimalloc",
  "oauth2",
  "rand 0.10.0",
+ "reqwest",
  "rocket",
  "serde",
  "serde_json",

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,6 +51,10 @@ services:
 
       WEBHOOK_BASIC_USER: "user"
       WEBHOOK_BASIC_PASSWORD: "password"
+
+      GITHUB_TOKEN: ""
+      GITHUB_REPO_OWNER: ""
+      GITHUB_REPO_NAME: ""
     volumes:
       - webhook:/data/spool
     healthcheck:

--- a/crates/wazuh-cert-oauth2-webhook/Cargo.toml
+++ b/crates/wazuh-cert-oauth2-webhook/Cargo.toml
@@ -18,6 +18,7 @@ mimalloc.workspace = true
 rand.workspace = true
 base64.workspace = true
 unwrap-infallible.workspace = true
+reqwest.workspace = true
 
 [dependencies.wazuh-cert-oauth2-model]
 workspace = true

--- a/crates/wazuh-cert-oauth2-webhook/src/bootstrap.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/bootstrap.rs
@@ -29,6 +29,9 @@ pub fn build_state(opt: &Opt) -> AppResult<ProxyState> {
         opt.webhook_basic_password.clone(),
         opt.webhook_api_key.clone(),
         opt.webhook_bearer_token.clone(),
+        opt.github_token.clone(),
+        opt.github_repo_owner.clone(),
+        opt.github_repo_name.clone(),
     )?;
     Ok(state)
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook.rs
@@ -1,15 +1,14 @@
-use rocket::State;
-use rocket::http::Status;
-use rocket::serde::json::Json;
-use tracing::{debug, info, warn};
-use wazuh_cert_oauth2_model::models::errors::AppResult;
-use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
-
 use crate::handlers::auth::WebhookAuth;
 use crate::handlers::webhook_util::{extract_user_id, prepare_github_issue};
 use crate::models::WebhookRequest;
 use crate::state::ProxyState;
 use crate::state::core::EventAction;
+use crate::state::spool::GitHubTicket;
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::{State, post};
+use tracing::{debug, error, info, warn};
+use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
 
 #[post("/webhook", format = "application/json", data = "<payload>")]
 #[tracing::instrument(skip(_auth, state, payload), fields(event_type = %payload.event_type, resource = ?payload.resource_path))]
@@ -42,58 +41,17 @@ async fn handle_create_ticket(
     state: &State<ProxyState>,
     p: WebhookRequest,
 ) -> Result<Status, Status> {
-    info!(
-        "handling create ticket event; type={} resourcePath={:?}",
-        p.event_type, p.resource_path
-    );
-
-    let (token, owner, name) = match (
-        &state.github_token,
-        &state.github_repo_owner,
-        &state.github_repo_name,
-    ) {
-        (Some(t), Some(o), Some(n)) => (t, o, n),
-        _ => {
-            warn!("ticket creation requested but GitHub config is incomplete");
-            return Ok(Status::Ok);
-        }
-    };
-
     let (title, body) = prepare_github_issue(&p);
-    let url = format!("https://api.github.com/repos/{}/{}/issues", owner, name);
-    let payload = serde_json::json!({
-        "title": title,
-        "body": body,
-    });
+    let ticket = GitHubTicket { title, body };
 
-    let resp: AppResult<reqwest::Response> = state
-        .execute_with_retry(|| async {
-            let builder = state
-                .http
-                .client()
-                .post(&url)
-                .header("User-Agent", "wazuh-cert-oauth2-webhook")
-                .header("Accept", "application/vnd.github.v3+json")
-                .bearer_auth(token)
-                .json(&payload);
-            Ok(builder)
-        })
-        .await;
-
-    match resp {
-        Ok(r) => {
-            if r.status().is_success() {
-                info!("successfully created GitHub ticket for user creation");
-            } else {
-                error!(
-                    "failed to create GitHub ticket: upstream returned status={}, body={:?}",
-                    r.status(),
-                    r.text().await.unwrap_or_default()
-                );
-            }
-        }
-        Err(e) => {
-            error!("failed to send GitHub ticket creation request: {}", e);
+    if let Err(e) = state.forward_github_ticket_with_retry(ticket.clone()).await {
+        warn!(
+            "initial GitHub ticket creation failed; spooling for retry: {}",
+            e
+        );
+        if let Err(se) = state.queue_github_ticket(ticket).await {
+            error!("CRITICAL: failed to spool GitHub ticket: {}", se);
+            return Err(Status::InternalServerError);
         }
     }
 

--- a/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook.rs
@@ -2,10 +2,11 @@ use rocket::State;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use tracing::{debug, info, warn};
+use wazuh_cert_oauth2_model::models::errors::AppResult;
 use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
 
 use crate::handlers::auth::WebhookAuth;
-use crate::handlers::webhook_util::extract_user_id;
+use crate::handlers::webhook_util::{extract_user_id, prepare_github_issue};
 use crate::models::WebhookRequest;
 use crate::state::ProxyState;
 use crate::state::core::EventAction;
@@ -32,7 +33,73 @@ pub async fn send_webhook(
         }
         EventAction::Revoke => handle_revoke(state, p).await,
         EventAction::Enabled => handle_enable(state, p).await,
+        EventAction::CreateTicket => handle_create_ticket(state, p).await,
     }
+}
+
+#[tracing::instrument(skip(state, p), fields(event_type = %p.event_type))]
+async fn handle_create_ticket(
+    state: &State<ProxyState>,
+    p: WebhookRequest,
+) -> Result<Status, Status> {
+    info!(
+        "handling create ticket event; type={} resourcePath={:?}",
+        p.event_type, p.resource_path
+    );
+
+    let (token, owner, name) = match (
+        &state.github_token,
+        &state.github_repo_owner,
+        &state.github_repo_name,
+    ) {
+        (Some(t), Some(o), Some(n)) => (t, o, n),
+        _ => {
+            warn!("ticket creation requested but GitHub config is incomplete");
+            return Ok(Status::Ok);
+        }
+    };
+
+    let (title, body) = prepare_github_issue(&p);
+    let url = format!("https://api.github.com/repos/{}/{}/issues", owner, name);
+    let payload = serde_json::json!({
+        "title": title,
+        "body": body,
+    });
+
+    let resp: AppResult<reqwest::Response> = state
+        .execute_with_retry(|| async {
+            let builder = state
+                .http
+                .client()
+                .post(&url)
+                .header("User-Agent", "wazuh-cert-oauth2-webhook")
+                .header("Accept", "application/vnd.github.v3+json")
+                .bearer_auth(token)
+                .json(&payload);
+            Ok(builder)
+        })
+        .await;
+
+    match resp {
+        Ok(r) => {
+            if r.status().is_success() {
+                info!("successfully created GitHub ticket for user creation");
+            } else {
+                error!(
+                    "failed to create GitHub ticket: upstream returned status={}, body={:?}",
+                    r.status(),
+                    r.text().await.unwrap_or_default()
+                );
+            }
+        }
+        Err(e) => {
+            error!("failed to send GitHub ticket creation request: {}", e);
+        }
+    }
+
+    // We return Ok always to avoid Keycloak retrying the webhook indefinitely
+    // if the GitHub API is having issues.
+    Ok(Status::Ok)
 }
 
 #[tracing::instrument(skip(state), fields(event_type = %p.event_type))]

--- a/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook_util.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/handlers/webhook_util.rs
@@ -1,7 +1,7 @@
 use crate::models::{SimpleUserRepresentation, WebhookRequest};
 
 pub(super) fn extract_user_id(p: &WebhookRequest) -> Option<String> {
-    if let Ok(SimpleUserRepresentation { id, .. }) = &p.get_simple_user_representation() {
+    if let Ok(SimpleUserRepresentation { id: Some(id), .. }) = &p.get_simple_user_representation() {
         return Some(id.to_string());
     }
 
@@ -16,6 +16,43 @@ pub(super) fn extract_user_id(p: &WebhookRequest) -> Option<String> {
         }
     }
     None
+}
+
+pub fn prepare_github_issue(p: &WebhookRequest) -> (String, String) {
+    let user = p.get_simple_user_representation().ok();
+
+    // Extract Email: representation > unknown
+    let email = user
+        .as_ref()
+        .and_then(|u| u.email.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Extract Username: representation.username > representation.first+last > "unknown"
+    let username = user
+        .as_ref()
+        .and_then(|u| u.username.clone())
+        .or_else(|| {
+            user.as_ref()
+                .and_then(|u| match (&u.first_name, &u.last_name) {
+                    (Some(f), Some(l)) => Some(format!("{} {}", f, l)),
+                    (Some(f), None) => Some(f.clone()),
+                    (None, Some(l)) => Some(l.clone()),
+                    (None, None) => None,
+                })
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let title = format!("New user registered: {}", username);
+    let body = format!(
+        "A new user has been registered in Keycloak.\n\
+        ---\n\n\
+         - **Username**: {}\n\
+         - **Email**: {}\n\
+         - **Realm**: {}",
+        username, email, p.realm_id
+    );
+
+    (title, body)
 }
 
 #[cfg(test)]

--- a/crates/wazuh-cert-oauth2-webhook/src/models.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/models.rs
@@ -65,11 +65,14 @@ impl WebhookRequest {
 }
 
 #[derive(Deserialize, Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleUserRepresentation {
-    pub id: String,
+    pub id: Option<String>,
     pub enabled: bool,
-    pub username: String,
-    pub email: String,
+    pub username: Option<String>,
+    pub email: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
 }
 
 #[cfg(test)]
@@ -110,9 +113,9 @@ mod tests {
         let user = req
             .get_simple_user_representation()
             .expect("representation should parse");
-        assert_eq!(user.id, "user-1");
+        assert_eq!(user.id, Some("user-1".to_string()));
         assert!(!user.enabled);
-        assert_eq!(user.username, "alice");
+        assert_eq!(user.username, Some("alice".to_string()));
     }
 
     #[test]

--- a/crates/wazuh-cert-oauth2-webhook/src/opts.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/opts.rs
@@ -61,4 +61,14 @@ pub struct Opt {
     pub webhook_api_key: Option<String>,
     #[arg(long, env = "WEBHOOK_BEARER_TOKEN")]
     pub webhook_bearer_token: Option<String>,
+
+    // GitHub Ticket Creation (for REGISTER/USER_CREATE events)
+    #[arg(long, env = "GITHUB_TOKEN")]
+    pub github_token: Option<String>,
+
+    #[arg(long, env = "GITHUB_REPO_OWNER")]
+    pub github_repo_owner: Option<String>,
+
+    #[arg(long, env = "GITHUB_REPO_NAME")]
+    pub github_repo_name: Option<String>,
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/builder.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/builder.rs
@@ -28,6 +28,9 @@ impl ProxyState {
         webhook_basic_password: Option<String>,
         webhook_api_key: Option<String>,
         webhook_bearer_token: Option<String>,
+        github_token: Option<String>,
+        github_repo_owner: Option<String>,
+        github_repo_name: Option<String>,
     ) -> AppResult<Self> {
         utils::ensure_spool_dir(&spool_dir);
         let oauth = oauth::build_oauth(
@@ -52,6 +55,9 @@ impl ProxyState {
             webhook_basic_password,
             webhook_api_key,
             webhook_bearer_token,
+            github_token,
+            github_repo_owner,
+            github_repo_name,
             token_cache: Arc::new(RwLock::new(None)),
         })
     }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
@@ -2,6 +2,7 @@ use super::ProxyState;
 use super::oauth;
 use super::spool;
 use crate::models::WebhookRequest;
+use crate::state::spool::GitHubTicket;
 use wazuh_cert_oauth2_model::models::errors::{AppError, AppResult};
 use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
 
@@ -74,6 +75,60 @@ impl ProxyState {
         }
     }
 
+    #[tracing::instrument(skip(self, ticket))]
+    pub async fn forward_github_ticket_with_retry(&self, ticket: GitHubTicket) -> AppResult<()> {
+        let (token, owner, name) = match (
+            &self.github_token,
+            &self.github_repo_owner,
+            &self.github_repo_name,
+        ) {
+            (Some(t), Some(o), Some(n)) => (t, o, n),
+            _ => {
+                tracing::warn!(
+                    "Forwarding GitHub ticket requested but GitHub config is incomplete"
+                );
+                return Ok(());
+            }
+        };
+
+        let url = format!("https://api.github.com/repos/{}/{}/issues", owner, name);
+        let payload = serde_json::json!({
+            "title": ticket.title,
+            "body": ticket.body,
+        });
+
+        let resp = self
+            .execute_with_retry(|| async {
+                let builder = self
+                    .http
+                    .client()
+                    .post(&url)
+                    .header("User-Agent", "wazuh-cert-oauth2-webhook")
+                    .header("Accept", "application/vnd.github.v3+json")
+                    .bearer_auth(token)
+                    .json(&payload);
+                Ok(builder)
+            })
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::error!(
+                "failed to create GitHub ticket: upstream returned status={}, body={:?}",
+                status,
+                body
+            );
+            return Err(AppError::UpstreamError(format!(
+                "GitHub ticket creation failed with status {}",
+                status
+            )));
+        }
+
+        tracing::info!("successfully created GitHub ticket");
+        Ok(())
+    }
+
     #[tracing::instrument(skip(self))]
     async fn acquire_token(&self) -> AppResult<Option<String>> {
         if let Some(s) = &self.static_bearer {
@@ -141,6 +196,10 @@ impl ProxyState {
 
     pub async fn queue_revoke(&self, req: RevokeRequest) -> AppResult<()> {
         spool::queue_revoke_to_spool_dir(self, req).await
+    }
+
+    pub async fn queue_github_ticket(&self, ticket: GitHubTicket) -> AppResult<()> {
+        spool::queue_github_ticket_to_spool_dir(self, ticket).await
     }
 
     pub async fn cancel_pending_revokes_for_subject(&self, subject: &str) -> AppResult<usize> {

--- a/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
@@ -9,35 +9,17 @@ impl ProxyState {
     #[tracing::instrument(skip(self, req), fields(subject = %req.subject.as_deref().unwrap_or(""), serial = %req.serial_hex.as_deref().unwrap_or("")))]
     pub async fn forward_revoke_with_retry(&self, req: RevokeRequest) -> AppResult<()> {
         let url = format!("{}/api/revoke", self.server_base_url.trim_end_matches('/'));
-        let mut attempt: u32 = 0;
-        let max = self.retry_attempts.max(1);
-        let mut delay = self.retry_base;
-        loop {
-            attempt += 1;
-            match self.try_send(&url, &req).await {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    if attempt >= max {
-                        return Err(e);
-                    }
-                    tokio::time::sleep(delay).await;
-                    delay = std::cmp::min(self.retry_max, delay.saturating_mul(2));
+        let resp = self
+            .execute_with_retry(|| async {
+                let token = self.acquire_token().await?;
+                let mut builder = self.http.client().post(&url).json(&req);
+                if let Some(t) = token {
+                    builder = builder.bearer_auth(t);
                 }
-            }
-        }
-    }
+                Ok(builder)
+            })
+            .await?;
 
-    #[tracing::instrument(skip(self, req))]
-    async fn try_send(&self, url: &str, req: &RevokeRequest) -> AppResult<()> {
-        let token = self.acquire_token().await?;
-        let builder = self.http.client().post(url).json(req);
-        let builder = if let Some(t) = token {
-            builder.bearer_auth(t)
-        } else {
-            builder
-        };
-
-        let resp = builder.send().await?;
         if resp.status().as_u16() == 401 {
             let mut guard = self.token_cache.write().await;
             *guard = None;
@@ -48,6 +30,48 @@ impl ProxyState {
         }
 
         Ok(())
+    }
+
+    pub async fn execute_with_retry<F, Fut>(&self, f: F) -> AppResult<reqwest::Response>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = AppResult<reqwest::RequestBuilder>>,
+    {
+        let mut attempt: u32 = 0;
+        let max = self.retry_attempts.max(1);
+        let mut delay = self.retry_base;
+        loop {
+            attempt += 1;
+            let builder: reqwest::RequestBuilder = f().await?;
+            match builder.send().await {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        return Ok(resp);
+                    }
+                    if resp.status().is_server_error() && attempt < max {
+                        tracing::warn!(
+                            "Upstream server error (status={}); retrying (attempt {}/{})",
+                            resp.status(),
+                            attempt,
+                            max
+                        );
+                    } else {
+                        return Ok(resp);
+                    }
+                }
+                Err(e) if (e.is_connect() || e.is_timeout()) && attempt < max => {
+                    tracing::warn!(
+                        "Upstream connection error: {}; retrying (attempt {}/{})",
+                        e,
+                        attempt,
+                        max
+                    );
+                }
+                Err(e) => return Err(e.into()),
+            }
+            tokio::time::sleep(delay).await;
+            delay = std::cmp::min(self.retry_max, delay.saturating_mul(2));
+        }
     }
 
     #[tracing::instrument(skip(self))]
@@ -84,6 +108,11 @@ impl ProxyState {
 
             return EventAction::Revoke;
         }
+
+        if t == "register" || t == "user-create" {
+            return EventAction::CreateTicket;
+        }
+
         EventAction::Ignore
     }
 
@@ -124,6 +153,7 @@ pub enum EventAction {
     Revoke,
     Enabled,
     Ignore,
+    CreateTicket,
 }
 
 #[cfg(test)]
@@ -168,6 +198,9 @@ mod tests {
             webhook_basic_password,
             webhook_api_key,
             webhook_bearer_token,
+            None,
+            None,
+            None,
         )
         .expect("state should build")
     }
@@ -230,5 +263,23 @@ mod tests {
         let with_api_key = build_state(Some("secret-key".to_string()), None, None, None);
         assert!(!with_api_key.webhook_allows_anonymous());
         assert_eq!(with_api_key.webhook_api_key(), Some("secret-key"));
+    }
+
+    #[test]
+    fn register_event_maps_to_create_ticket_action() {
+        let state = build_state(None, None, None, None);
+        let req = webhook_request("REGISTER", None, None);
+
+        let action = state.is_allowed_event("register", &req);
+        assert_eq!(action, EventAction::CreateTicket);
+    }
+
+    #[test]
+    fn user_create_event_maps_to_create_ticket_action() {
+        let state = build_state(None, None, None, None);
+        let req = webhook_request("USER-CREATE", None, None);
+
+        let action = state.is_allowed_event("user-create", &req);
+        assert_eq!(action, EventAction::CreateTicket);
     }
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
@@ -33,6 +33,10 @@ pub struct ProxyState {
     webhook_api_key: Option<String>,
     webhook_bearer_token: Option<String>,
 
+    pub(crate) github_token: Option<String>,
+    pub(crate) github_repo_owner: Option<String>,
+    pub(crate) github_repo_name: Option<String>,
+
     pub(crate) token_cache: Arc<RwLock<Option<oauth::CachedToken>>>,
 }
 

--- a/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
@@ -8,7 +8,7 @@ use wazuh_cert_oauth2_model::services::http_client::HttpClient;
 mod builder;
 pub(crate) mod core;
 mod oauth;
-mod spool;
+pub mod spool;
 mod utils;
 
 pub use spool::spawn_spool_processor;

--- a/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
@@ -10,9 +10,16 @@ use wazuh_cert_oauth2_model::models::revoke_request::RevokeRequest;
 
 use super::ProxyState;
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GitHubTicket {
+    pub title: String,
+    pub body: String,
+}
+
 #[derive(Serialize, Deserialize)]
-struct SpoolItem {
-    req: RevokeRequest,
+enum SpoolItem {
+    RevokeRequest { req: RevokeRequest },
+    GitHubTicket { ticket: GitHubTicket },
 }
 
 /// Remove queued revoke requests targeting the given subject.
@@ -37,8 +44,8 @@ pub async fn cancel_pending_revokes_for_subject(
         }
         match tokio::fs::read(&path).await {
             Ok(bytes) => match serde_json::from_slice::<SpoolItem>(&bytes) {
-                Ok(item) => {
-                    if item.req.subject.as_deref() == Some(subject) {
+                Ok(SpoolItem::RevokeRequest { req }) => {
+                    if req.subject.as_deref() == Some(subject) {
                         debug!(
                             "canceling pending revoke for {} in {}",
                             subject,
@@ -52,6 +59,7 @@ pub async fn cancel_pending_revokes_for_subject(
                         }
                     }
                 }
+                Ok(SpoolItem::GitHubTicket { .. }) => { /* Ignore GitHubTicket */ }
                 Err(e) => {
                     // Leave invalid files to the regular processor to clean up
                     warn!("invalid spool item {}; skipping: {}", path.display(), e);
@@ -65,7 +73,7 @@ pub async fn cancel_pending_revokes_for_subject(
 
 #[tracing::instrument(skip(state, req))]
 pub async fn queue_revoke_to_spool_dir(state: &ProxyState, req: RevokeRequest) -> AppResult<()> {
-    let item = SpoolItem { req };
+    let item = SpoolItem::RevokeRequest { req };
     let data = serde_json::to_vec(&item)?;
     let ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -78,6 +86,31 @@ pub async fn queue_revoke_to_spool_dir(state: &ProxyState, req: RevokeRequest) -
         rid.push_str(&format!("{:02x}", b));
     }
     let filename = format!("revoke-{}-{}.json", ms, rid);
+    let path = state.spool_dir.join(&filename);
+    let tmp = state.spool_dir.join(format!("{}.tmp", filename));
+    tokio::fs::write(&tmp, data).await?;
+    tokio::fs::rename(&tmp, &path).await?;
+    Ok(())
+}
+
+#[tracing::instrument(skip(state, ticket))]
+pub async fn queue_github_ticket_to_spool_dir(
+    state: &ProxyState,
+    ticket: GitHubTicket,
+) -> AppResult<()> {
+    let item = SpoolItem::GitHubTicket { ticket };
+    let data = serde_json::to_vec(&item)?;
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let mut buf = [0u8; 8];
+    rand::rng().try_fill_bytes(&mut buf).unwrap_infallible();
+    let mut rid = String::with_capacity(buf.len() * 2);
+    for b in buf {
+        rid.push_str(&format!("{:02x}", b));
+    }
+    let filename = format!("ticket-{}-{}.json", ms, rid);
     let path = state.spool_dir.join(&filename);
     let tmp = state.spool_dir.join(format!("{}.tmp", filename));
     tokio::fs::write(&tmp, data).await?;
@@ -118,9 +151,18 @@ async fn process_once(state: &ProxyState) -> AppResult<()> {
             Ok(bytes) => match serde_json::from_slice::<SpoolItem>(&bytes) {
                 Ok(item) => {
                     debug!("processing spool file: {}", path.display());
-                    match state.forward_revoke_with_retry(item.req).await {
+                    let res = match item {
+                        SpoolItem::RevokeRequest { req } => {
+                            state.forward_revoke_with_retry(req).await
+                        }
+                        SpoolItem::GitHubTicket { ticket } => {
+                            state.forward_github_ticket_with_retry(ticket).await
+                        }
+                    };
+
+                    match res {
                         Ok(()) => {
-                            debug!("forwarded; removing {}", path.display());
+                            debug!("successfully processed {}; removing", path.display());
                             let _ = tokio::fs::remove_file(&path).await;
                         }
                         Err(e) => warn!("still failing for {}: {}", path.display(), e),
@@ -257,7 +299,10 @@ mod tests {
             .await
             .expect("remaining file should be readable");
         let item: SpoolItem = serde_json::from_slice(&bytes).expect("json should parse");
-        assert_eq!(item.req.subject.as_deref(), Some("user-b"));
+        match item {
+            SpoolItem::RevokeRequest { req } => assert_eq!(req.subject.as_deref(), Some("user-b")),
+            _ => panic!("Expected RevokeRequest variant"),
+        }
 
         let _ = fs::remove_dir_all(&spool_dir).await;
     }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
@@ -179,6 +179,9 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .expect("state should build")
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,9 +89,33 @@ sequenceDiagram
     end
 ```
 
+### 3. User Registration Tracking (GitHub Issue Flow)
+
+When a new user registers or is created in Keycloak, the Webhook Proxy handles the event and creates an issue in GitHub for administrative tracking.
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant Keycloak as Keycloak (IdP)
+    participant Webhook as Webhook Proxy (wazuh-cert-oauth2-webhook)
+    participant GitHub as GitHub API
+
+    Keycloak->>Webhook: POST /webhook (User Registered/Created)
+    Webhook->>Webhook: Extract User Metadata (Email, Username, Realm)
+    Webhook->>GitHub: POST /repos/{owner}/{repo}/issues
+    
+    alt Success
+        GitHub-->>Webhook: 201 Created
+    else Network Error / 5xx
+        Webhook->>Webhook: Retry with Exponential Backoff
+    end
+```
+
 #### Webhook Details:
-- **Resiliency**: The Webhook Proxy includes a persistent spooling mechanism. If the Certificate Server is unavailable, revocation requests are queued and retried automatically.
-- **Filtering**: Not all Keycloak events trigger a revocation. The proxy is configured to listen specifically for events that imply a user should no longer have access (e.g., account deletion or disabling).
+- **Resiliency**: The Webhook Proxy includes a persistent spooling mechanism and automatic retries with exponential backoff for all upstream requests (Certificate Server and GitHub API).
+- **Filtering**: The proxy identifies revoke-eligible events (`USER-DELETE`/`USER-UPDATE`) and ticket-eligible events (`REGISTER`/`USER-CREATE`).
+- **GitHub Integration**: For registration events, the proxy automatically creates a tracking issue in the configured GitHub repository.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,9 @@
 
 This guide covers the prerequisites, dependencies, and steps to get the `wazuh-cert-oauth2` project running locally.
 
+> [!NOTE]
+> **GitHub Integration**: The Webhook Proxy supports automated GitHub issue creation for new user registrations in Keycloak. To use this feature, you will need a GitHub Personal Access Token (preferably a **fine-grained** token with only **Issue Creation** permissions), the repository owner, and the repository name. See the [Configuration Reference](#webhook-flags) for details.
+
 ## Prerequisites
 
 Before building or running the project, ensure you have the following installed:
@@ -110,6 +113,9 @@ export RUST_LOG=info,reqwest=warn
 | `--spool-dir` | `SPOOL_DIR` | `/data/spool` | Directory for persistent retry spooling. |
 | `--oauth-client-id` | `OAUTH_CLIENT_ID` | (Required) | Client ID to talk to the Server. |
 | `--oauth-client-secret`| `OAUTH_CLIENT_SECRET`| (Required) | Client Secret for the Server. |
+| `--github-token` | `GITHUB_TOKEN` | (Optional) | GitHub PAT for issue creation. |
+| `--github-repo-owner`| `GITHUB_REPO_OWNER` | (Optional) | Owner of the repo for tickets. |
+| `--github-repo-name` | `GITHUB_REPO_NAME` | (Optional) | Name of the repo for tickets. |
 
 ### Client Flags
 | Flag | Env Variable | Default | Purpose |


### PR DESCRIPTION
## Summary

This PR enhances the `wazuh-cert-oauth2-webhook` service by introducing automated GitHub issue creation for new user registrations and registration events in Keycloak. It also refactors the retry logic into a centralized, robust helper with exponential backoff to handle transient network failures consistently across all upstream integrations.

## Related Issues

Closes #199 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] CI/CD or tooling

## Changes Made

- **GitHub Integration**: Implemented issue creation for `REGISTER` and `USER-CREATE` Keycloak events.
- **Retry Mechanism**: Added `ProxyState::execute_with_retry` method for exponential backoff on connection/server errors.
- **Configuration**: Added `GITHUB_TOKEN`, `GITHUB_REPO_OWNER`, and `GITHUB_REPO_NAME` environment variables.
- **Documentation**: Updated [getting-started.md](https://github.com/ADORSYS-GIS/wazuh-cert-oauth2/blob/feat/webhook-improvements/docs/getting-started.md) and [architecture.md](https://github.com/ADORSYS-GIS/wazuh-cert-oauth2/blob/feat/webhook-improvements/docs/architecture.md) with the new feature details and setup prerequisites.

## Checklist

- [x] Code follows the project's style (`cargo fmt`)
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] All tests pass (`cargo test`)
- [x] No new clippy warnings (`cargo clippy -- -D warnings`)
- [x] Documentation updated if needed

## Security Considerations

Does this PR have security implications? (authentication, certificates, cryptography, etc.)

- [ ] No security impact
- [x] Security impact reviewed (describe below)

The integration requires a GitHub Personal Access Token. It is strongly recommended to use a fine-grained PAT with **Issue Creation** permissions only(recomended). The token is handled via environment variables and is not logged.

## Testing

How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing with `docker compose`
- [ ] Other:
