### PR TITLE
feat: Add overwrite flag, enforce single active cert, and expose audi…

### DIFF
--- a/.docker/keycloak_config/realm.json
+++ b/.docker/keycloak_config/realm.json
@@ -36,6 +36,26 @@
           "value": "test"
         }
       ]
+    },
+    {
+      "username": "service-account-test-client",
+      "enabled": true,
+      "serviceAccountClientId": "test-client",
+      "clientRoles": {
+        "realm-management": [
+          "view-users"
+        ]
+      }
+    },
+    {
+      "username": "service-account-test-client-secret",
+      "enabled": true,
+      "serviceAccountClientId": "test-client-secret",
+      "clientRoles": {
+        "realm-management": [
+          "view-users"
+        ]
+      }
     }
   ],
   "clients": [
@@ -63,7 +83,7 @@
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
+      "serviceAccountsEnabled": true,
       "publicClient": true,
       "frontchannelLogout": true,
       "protocol": "openid-connect",
@@ -124,7 +144,7 @@
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
+      "serviceAccountsEnabled": true,
       "publicClient": false,
       "frontchannelLogout": true,
       "protocol": "openid-connect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1219,7 +1219,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2056,7 +2056,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2093,9 +2093,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2450,7 +2450,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,6 +51,7 @@ services:
 
       WEBHOOK_BASIC_USER: "user"
       WEBHOOK_BASIC_PASSWORD: "password"
+      KEYCLOAK_ADMIN_BASE_URL: "http://keycloak:9100/admin/realms/dev"
     volumes:
       - webhook:/data/spool
     healthcheck:

--- a/crates/wazuh-cert-oauth2-client/src/flow.rs
+++ b/crates/wazuh-cert-oauth2-client/src/flow.rs
@@ -24,6 +24,7 @@ pub struct FlowParams {
     ca_cert_path: String,
     key_path: String,
     agent_control: bool,
+    overwrite: bool,
 }
 
 impl From<Opt> for FlowParams {
@@ -40,6 +41,7 @@ impl From<Opt> for FlowParams {
                 ca_cert_path,
                 key_path,
                 agent_control,
+                overwrite,
             } => Self {
                 issuer,
                 audience_csv: audience,
@@ -51,6 +53,7 @@ impl From<Opt> for FlowParams {
                 key_path,
                 agent_control,
                 ca_cert_path,
+                overwrite,
             },
         }
     }
@@ -95,8 +98,8 @@ pub async fn run_oauth2_flow(params: &FlowParams) -> AppResult<()> {
     debug!("Generating keypair and CSR");
     let (csr_pem, private_key_pem) = generate_key_and_csr(&sub)?;
 
-    debug!("Submitting CSR for signing");
-    let signed = submit_csr(&http, &params.endpoint, &token, &csr_pem).await?;
+    debug!("Submitting CSR for signing, overwrite={}", params.overwrite);
+    let signed = submit_csr(&http, &params.endpoint, &token, &csr_pem, params.overwrite).await?;
 
     debug!("Saving certificate and private key");
     save_cert_and_key(
@@ -144,6 +147,7 @@ mod tests {
             ca_cert_path: "/tmp/ca.pem".to_string(),
             key_path: "/tmp/client.key".to_string(),
             agent_control: false,
+            overwrite: true,
         };
 
         let params = FlowParams::from(opt);
@@ -158,5 +162,6 @@ mod tests {
         assert_eq!(params.ca_cert_path, "/tmp/ca.pem");
         assert_eq!(params.key_path, "/tmp/client.key");
         assert!(!params.agent_control);
+        assert!(params.overwrite);
     }
 }

--- a/crates/wazuh-cert-oauth2-client/src/services/get_token.rs
+++ b/crates/wazuh-cert-oauth2-client/src/services/get_token.rs
@@ -106,26 +106,33 @@ fn open_in_browser(url: &str) -> bool {
     ))]
     {
         use std::env;
-        if let Ok(user) = env::var("SUDO_USER") {
-            let mut cmd = Command::new("runuser");
-            cmd.arg("-u").arg(&user).arg("--").arg("xdg-open").arg(url);
+        let mut cmd = if let Ok(user) = env::var("SUDO_USER") {
+            // Running under sudo: drop back to the original user so xdg-open
+            // can reach their desktop session.
+            let mut c = Command::new("runuser");
+            c.arg("-u").arg(&user).arg("--").arg("xdg-open").arg(url);
+            c
+        } else {
+            let mut c = Command::new("xdg-open");
+            c.arg(url);
+            c
+        };
 
-            // Forward display and dbus session so xdg-open works cleanly
-            if let Ok(display) = env::var("DISPLAY") {
-                cmd.env("DISPLAY", display);
-            }
-            if let Ok(wayland) = env::var("WAYLAND_DISPLAY") {
-                cmd.env("WAYLAND_DISPLAY", wayland);
-            }
-            if let Ok(dbus) = env::var("DBUS_SESSION_BUS_ADDRESS") {
-                cmd.env("DBUS_SESSION_BUS_ADDRESS", dbus);
-            }
-
-            // Suppress GTK noise when using firefox as the default browser, which is common on Linux.
-            cmd.stderr(std::fs::File::open("/dev/null").unwrap());
-
-            return cmd.spawn().map(|_| true).unwrap_or(false);
+        // Forward display and dbus session so xdg-open works cleanly.
+        if let Ok(display) = env::var("DISPLAY") {
+            cmd.env("DISPLAY", display);
         }
+        if let Ok(wayland) = env::var("WAYLAND_DISPLAY") {
+            cmd.env("WAYLAND_DISPLAY", wayland);
+        }
+        if let Ok(dbus) = env::var("DBUS_SESSION_BUS_ADDRESS") {
+            cmd.env("DBUS_SESSION_BUS_ADDRESS", dbus);
+        }
+
+        // Suppress GTK noise (e.g. Firefox as default browser).
+        cmd.stderr(std::fs::File::open("/dev/null").unwrap());
+
+        return cmd.spawn().map(|_| true).unwrap_or(false);
     }
 
     // Fallback for any other targets: do nothing.

--- a/crates/wazuh-cert-oauth2-client/src/services/submit_csr.rs
+++ b/crates/wazuh-cert-oauth2-client/src/services/submit_csr.rs
@@ -9,9 +9,11 @@ pub async fn submit_csr(
     endpoint: &str,
     token: &str,
     csr_pem: &str,
+    overwrite: bool,
 ) -> AppResult<SignedCertResponse> {
     let dto = SignCsrRequest {
         csr_pem: csr_pem.to_string(),
+        overwrite: Some(overwrite),
     };
     http.post_json_auth(endpoint, token, &dto).await
 }

--- a/crates/wazuh-cert-oauth2-client/src/shared/cli.rs
+++ b/crates/wazuh-cert-oauth2-client/src/shared/cli.rs
@@ -50,6 +50,9 @@ pub enum Opt {
 
         #[arg(env, long, default_value_t = true, action = ArgAction::Set, default_missing_value = "true", num_args = 0..=1)]
         agent_control: bool,
+
+        #[arg(env, long, default_value_t = false, action = ArgAction::Set, default_missing_value = "true", num_args = 0..=1)]
+        overwrite: bool,
     },
 }
 
@@ -72,6 +75,7 @@ mod tests {
                 ca_cert_path,
                 key_path,
                 agent_control,
+                overwrite, // ignore
                 ..
             } => {
                 assert_eq!(issuer, "https://login.wazuh.adorsys.team/realms/adorsys");
@@ -85,6 +89,7 @@ mod tests {
                 assert_eq!(ca_cert_path, default_server_ca_cert_path());
                 assert_eq!(key_path, default_key_path());
                 assert!(agent_control);
+                assert!(!overwrite);
             }
         }
     }
@@ -94,6 +99,22 @@ mod tests {
         let parsed = Opt::parse_from(["client", "o-auth2", "--agent-control=false"]);
         match parsed {
             Opt::OAuth2 { agent_control, .. } => assert!(!agent_control),
+        }
+    }
+
+    #[test]
+    fn oauth2_cli_allows_overwrite_flag() {
+        let parsed = Opt::parse_from(["client", "o-auth2", "--overwrite", "true"]);
+        match parsed {
+            Opt::OAuth2 { overwrite, .. } => assert!(overwrite),
+        }
+    }
+
+    #[test]
+    fn oauth2_cli_overwrite_explicit_false() {
+        let parsed = Opt::parse_from(["client", "o-auth2", "--overwrite=false"]);
+        match parsed {
+            Opt::OAuth2 { overwrite, .. } => assert!(!overwrite),
         }
     }
 }

--- a/crates/wazuh-cert-oauth2-model/src/models/claims.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/claims.rs
@@ -9,7 +9,15 @@ pub struct Claims {
     pub exp: usize,
     #[serde(default)]
     pub preferred_username: Option<String>,
+    #[serde(default)]
+    pub realm_access: Option<RealmAccess>,
     // Add other claims as needed
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct RealmAccess {
+    #[serde(default)]
+    pub roles: Vec<String>,
 }
 
 impl Claims {
@@ -17,6 +25,13 @@ impl Claims {
         self.name
             .clone()
             .or_else(|| self.preferred_username.clone())
+    }
+
+    pub fn is_admin(&self) -> bool {
+        self.realm_access
+            .as_ref()
+            .map(|ra| ra.roles.iter().any(|r| r == "wazuh_admin"))
+            .unwrap_or(false)
     }
 }
 
@@ -31,6 +46,7 @@ mod tests {
             iss: "https://issuer.example/realms/main".to_string(),
             exp: 9_999_999_999,
             preferred_username: None,
+            realm_access: None,
         }
     }
 
@@ -55,5 +71,31 @@ mod tests {
     fn get_name_returns_none_when_missing() {
         let claims = base_claims();
         assert_eq!(claims.get_name(), None);
+    }
+
+    #[test]
+    fn is_admin_returns_true_when_wazuh_admin_role_present() {
+        use super::RealmAccess;
+        let mut claims = base_claims();
+        claims.realm_access = Some(RealmAccess {
+            roles: vec!["some_role".to_string(), "wazuh_admin".to_string()],
+        });
+        assert!(claims.is_admin());
+    }
+
+    #[test]
+    fn is_admin_returns_false_when_role_absent() {
+        use super::RealmAccess;
+        let mut claims = base_claims();
+        claims.realm_access = Some(RealmAccess {
+            roles: vec!["other_role".to_string()],
+        });
+        assert!(!claims.is_admin());
+    }
+
+    #[test]
+    fn is_admin_returns_false_when_realm_access_missing() {
+        let claims = base_claims();
+        assert!(!claims.is_admin());
     }
 }

--- a/crates/wazuh-cert-oauth2-model/src/models/errors.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/errors.rs
@@ -1,3 +1,9 @@
+use rocket::Request;
+use rocket::http::Status;
+use rocket::response::{Responder, Response};
+use rocket::serde::json::Json;
+use serde::Serialize;
+
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     // Generic
@@ -10,7 +16,10 @@ pub enum AppError {
     #[error("Upstream error: {0}")]
     UpstreamError(String),
 
-    #[error("Random error: {0}")]
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
+    #[error("Serialization error: {0}")]
     Serialization(String),
 
     #[error("Anyhow error: {0}")]
@@ -66,13 +75,13 @@ pub enum AppError {
     #[error("CLI error: {0}")]
     CliError(#[from] clap::Error),
 
-    #[error("OAuth2 Error error: {0}")]
+    #[error("OAuth2 HTTP error: {0}")]
     OAuth2Error(#[from] oauth2::http::Error),
 
-    #[error("Configuration Error error: {0}")]
+    #[error("OAuth2 configuration error: {0}")]
     ConfigurationError(#[from] oauth2::ConfigurationError),
 
-    #[error("Basic auth request error: {0}")]
+    #[error("OAuth2 request token error: {0}")]
     RequestTokenError(
         #[from]
         oauth2::RequestTokenError<
@@ -81,23 +90,21 @@ pub enum AppError {
         >,
     ),
 
-    #[error("URL Parse Error error: {0}")]
+    #[error("URL parse error: {0}")]
     UrlParseError(#[from] url::ParseError),
 
     #[cfg(feature = "openssl")]
-    #[error("URL Parse Error error: {0}")]
+    #[error("OpenSSL error: {0}")]
     ErrorStack(#[from] openssl::error::ErrorStack),
 
-    #[error("Parse JSON Error error: {0}")]
+    #[error("JSON parse error: {0}")]
     SerdeError(#[from] serde_json::Error),
 
-    //#[error("Random generation error: {0}")]
-    //RandOsError(#[from] rand_core::Error),
     #[error("Rand OS generation error: {0}")]
     RandOsError(#[from] rand::rngs::SysError),
 
     #[cfg(feature = "rocket")]
-    #[error("SetGlobalDefaultError error: {source}")]
+    #[error("SetGlobalDefaultError: {source}")]
     SetGlobalDefaultError {
         #[from]
         source: tracing::dispatcher::SetGlobalDefaultError,
@@ -106,6 +113,51 @@ pub enum AppError {
     // CRL / OpenSSL FFI
     #[error("CRL/OpenSSL FFI error in {func}")]
     CrlFfi { func: &'static str },
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+impl<'r> Responder<'r, 'static> for AppError {
+    fn respond_to(self, req: &'r Request<'_>) -> Result<Response<'static>, Status> {
+        let message = self.to_string();
+
+        let status = match &self {
+            AppError::UpstreamError(_) => Status::BadGateway,
+            AppError::Conflict(_) => Status::Conflict,
+            AppError::RequestTokenError(_) => Status::ServiceUnavailable,
+            AppError::CsrMissingPublicKey
+            | AppError::SerdeError(_)
+            | AppError::CsrVerificationFailed
+            | AppError::KeyPolicyRsaTooSmall { .. }
+            | AppError::KeyPolicyUnsupportedEcCurve { .. }
+            | AppError::KeyPolicyUnknownEcCurve
+            | AppError::KeyPolicyUnsupportedKeyType { .. } => Status::BadRequest,
+            _ => Status::InternalServerError,
+        };
+
+        if status == Status::InternalServerError {
+            tracing::error!("Internal server error: {}", message);
+        }
+
+        // Avoid leaking internal details (program names, FFI function names, etc.)
+        // for server-side errors. Client-facing errors (4xx) pass through as-is.
+        let client_message = if status.code >= 500 && status != Status::ServiceUnavailable {
+            "An internal error occurred".to_string()
+        } else {
+            message
+        };
+
+        let json = Json(ErrorResponse {
+            error: client_message,
+        });
+
+        Response::build_from(json.respond_to(req)?)
+            .status(status)
+            .ok()
+    }
 }
 
 // Convenience alias used where appropriate

--- a/crates/wazuh-cert-oauth2-model/src/models/ledger_entry.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/ledger_entry.rs
@@ -6,8 +6,12 @@ pub struct LedgerEntry {
     pub serial_hex: String,
     pub issued_at_unix: u64,
     pub revoked: bool,
+    #[serde(default)]
     pub revoked_at_unix: Option<u64>,
+    #[serde(default)]
     pub reason: Option<String>,
+    #[serde(default)]
     pub issuer: Option<String>,
+    #[serde(default)]
     pub realm: Option<String>,
 }

--- a/crates/wazuh-cert-oauth2-model/src/models/mod.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod claims;
 pub mod document;
 pub mod errors;
+pub mod ledger_entry;
 pub mod revoke_request;
 pub mod sign_csr_request;
 pub mod signed_cert_response;

--- a/crates/wazuh-cert-oauth2-model/src/models/sign_csr_request.rs
+++ b/crates/wazuh-cert-oauth2-model/src/models/sign_csr_request.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize)]
 pub struct SignCsrRequest {
     pub csr_pem: String,
+    #[serde(default)]
+    pub overwrite: Option<bool>,
 }
 
 #[cfg(test)]
@@ -13,10 +15,19 @@ mod tests {
     fn sign_csr_request_round_trip() {
         let req = SignCsrRequest {
             csr_pem: "-----BEGIN CERTIFICATE REQUEST-----...".to_string(),
+            overwrite: Some(true),
         };
 
         let json = serde_json::to_string(&req).expect("serialize should work");
         let parsed: SignCsrRequest = serde_json::from_str(&json).expect("parse should work");
         assert_eq!(parsed.csr_pem, req.csr_pem);
+    }
+
+    #[test]
+    fn overwrite_defaults_to_none_when_field_absent() {
+        // Older clients or raw API calls that omit the field must not fail deserialization
+        let json = r#"{"csr_pem":"-----BEGIN CERTIFICATE REQUEST-----..."}"#;
+        let parsed: SignCsrRequest = serde_json::from_str(json).expect("parse should work");
+        assert_eq!(parsed.overwrite, None);
     }
 }

--- a/crates/wazuh-cert-oauth2-model/src/services/http_client.rs
+++ b/crates/wazuh-cert-oauth2-model/src/services/http_client.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::models::errors::AppResult;
+use crate::models::errors::{AppError, AppResult};
 use reqwest::Client;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -38,6 +38,22 @@ impl HttpClient {
         Ok(resp.json().await?)
     }
 
+    #[instrument(level = "debug", skip(self, token))]
+    pub async fn fetch_json_auth<R: DeserializeOwned>(
+        &self,
+        url: &str,
+        token: &str,
+    ) -> AppResult<R> {
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(token)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
     #[instrument(level = "debug", skip(self, body))]
     pub async fn post_json<B: Serialize, R: DeserializeOwned>(
         &self,
@@ -67,8 +83,20 @@ impl HttpClient {
             .bearer_auth(token)
             .json(body)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+
+        if !resp.status().is_success() {
+            // Try to extract a structured error message from the JSON body
+            let status = resp.status();
+            let msg = resp
+                .json::<serde_json::Value>()
+                .await
+                .ok()
+                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+                .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
+            return Err(AppError::UpstreamError(msg));
+        }
+
         Ok(resp.json().await?)
     }
 }

--- a/crates/wazuh-cert-oauth2-server/src/handlers/ledger.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/ledger.rs
@@ -1,0 +1,12 @@
+use crate::handlers::middle::JwtToken;
+use crate::shared::ledger::Ledger;
+use crate::shared::ledger::LedgerEntry;
+use rocket::State;
+use rocket::serde::json::Json;
+
+/// Get all active (non-revoked) certificates from the ledger
+#[get("/ledger/active")]
+#[tracing::instrument(skip(token, ledger), fields(sub = %token.claims.sub))]
+pub async fn get_active_ledger(token: JwtToken, ledger: &State<Ledger>) -> Json<Vec<LedgerEntry>> {
+    Json(ledger.find_active().await)
+}

--- a/crates/wazuh-cert-oauth2-server/src/handlers/ledger.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/ledger.rs
@@ -4,9 +4,23 @@ use crate::shared::ledger::LedgerEntry;
 use rocket::State;
 use rocket::serde::json::Json;
 
-/// Get all active (non-revoked) certificates from the ledger
+/// All certificates (active and revoked)
+#[get("/ledger")]
+#[tracing::instrument(skip(token, ledger), fields(sub = %token.claims.sub))]
+pub async fn get_all_ledger(token: JwtToken, ledger: &State<Ledger>) -> Json<Vec<LedgerEntry>> {
+    Json(ledger.find_all().await)
+}
+
+/// Active (non-revoked) certificates only
 #[get("/ledger/active")]
 #[tracing::instrument(skip(token, ledger), fields(sub = %token.claims.sub))]
 pub async fn get_active_ledger(token: JwtToken, ledger: &State<Ledger>) -> Json<Vec<LedgerEntry>> {
     Json(ledger.find_active().await)
+}
+
+/// Revoked certificates only
+#[get("/ledger/revoked")]
+#[tracing::instrument(skip(token, ledger), fields(sub = %token.claims.sub))]
+pub async fn get_revoked_ledger(token: JwtToken, ledger: &State<Ledger>) -> Json<Vec<LedgerEntry>> {
+    Json(ledger.find_revoked().await)
 }

--- a/crates/wazuh-cert-oauth2-server/src/handlers/mod.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod crl;
 pub mod health;
+pub mod ledger;
 pub mod middle;
 pub mod register_agent;
 pub mod revoke;

--- a/crates/wazuh-cert-oauth2-server/src/handlers/register_agent.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/register_agent.rs
@@ -3,7 +3,6 @@ use crate::models::ca_config::CaProvider;
 use crate::shared::certs::sign_csr;
 use crate::shared::ledger::Ledger;
 use rocket::State;
-use rocket::http::Status;
 use rocket::serde::json::Json;
 use tracing::{debug, error, info};
 use wazuh_cert_oauth2_model::models::errors::AppError;
@@ -19,7 +18,7 @@ pub async fn register_agent(
     token: JwtToken,
     config: &State<CaProvider>,
     ledger: &State<Ledger>,
-) -> Result<Json<SignedCertResponse>, Status> {
+) -> Result<Json<SignedCertResponse>, AppError> {
     info!(
         "POST /register-agent called for subject={}",
         token.claims.sub
@@ -29,15 +28,7 @@ pub async fn register_agent(
         Ok(res) => Ok(Json(res)),
         Err(e) => {
             error!("CSR signing failed: {}", e);
-            match e {
-                AppError::CsrMissingPublicKey
-                | AppError::CsrVerificationFailed
-                | AppError::KeyPolicyRsaTooSmall { .. }
-                | AppError::KeyPolicyUnsupportedEcCurve { .. }
-                | AppError::KeyPolicyUnknownEcCurve
-                | AppError::KeyPolicyUnsupportedKeyType { .. } => Err(Status::BadRequest),
-                _ => Err(Status::InternalServerError),
-            }
+            Err(e)
         }
     }
 }

--- a/crates/wazuh-cert-oauth2-server/src/handlers/register_agent.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/register_agent.rs
@@ -1,6 +1,7 @@
 use crate::handlers::middle::JwtToken;
 use crate::models::ca_config::CaProvider;
 use crate::shared::certs::sign_csr;
+use crate::shared::crl::CrlState;
 use crate::shared::ledger::Ledger;
 use rocket::State;
 use rocket::serde::json::Json;
@@ -12,19 +13,28 @@ use wazuh_cert_oauth2_model::models::signed_cert_response::SignedCertResponse;
 /// Sign a CSR for a new agent using the issuing CA
 /// Expects a PKCS#10 CSR in PEM format; returns the signed certificate and CA cert
 #[post("/register-agent", format = "application/json", data = "<dto>")]
-#[tracing::instrument(skip(dto, token, config, ledger), fields(sub = %token.claims.sub))]
+#[tracing::instrument(skip(dto, token, config, ledger, crl), fields(sub = %token.claims.sub))]
 pub async fn register_agent(
     dto: Json<SignCsrRequest>,
     token: JwtToken,
     config: &State<CaProvider>,
     ledger: &State<Ledger>,
+    crl: &State<CrlState>,
 ) -> Result<Json<SignedCertResponse>, AppError> {
     info!(
         "POST /register-agent called for subject={}",
         token.claims.sub
     );
     debug!("CSR payload received (not logging PEM contents)");
-    match sign_csr(dto.into_inner(), token, config.inner(), ledger.inner()).await {
+    match sign_csr(
+        dto.into_inner(),
+        token,
+        config.inner(),
+        ledger.inner(),
+        crl.inner(),
+    )
+    .await
+    {
         Ok(res) => Ok(Json(res)),
         Err(e) => {
             error!("CSR signing failed: {}", e);

--- a/crates/wazuh-cert-oauth2-server/src/handlers/revoke.rs
+++ b/crates/wazuh-cert-oauth2-server/src/handlers/revoke.rs
@@ -64,11 +64,13 @@ async fn resolve_targets(
     };
     if let Some(subj) = subject {
         let entries = ledger.find_by_subject(&subj).await;
-        info!("found {} entries for subject", entries.len());
-        return if entries.is_empty() {
+        // Only target certificates that are not already revoked
+        let active_entries: Vec<_> = entries.into_iter().filter(|e| !e.revoked).collect();
+        info!("found {} active entries for subject", active_entries.len());
+        return if active_entries.is_empty() {
             Err(Status::NoContent)
         } else {
-            Ok(entries.into_iter().map(|e| e.serial_hex).collect())
+            Ok(active_entries.into_iter().map(|e| e.serial_hex).collect())
         };
     }
     Err(Status::BadRequest)

--- a/crates/wazuh-cert-oauth2-server/src/main.rs
+++ b/crates/wazuh-cert-oauth2-server/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::handlers::crl::{get_crl, get_revocations};
 use crate::handlers::health::health;
-use crate::handlers::ledger::get_active_ledger;
+use crate::handlers::ledger::{get_active_ledger, get_all_ledger, get_revoked_ledger};
 use crate::handlers::register_agent::register_agent;
 use crate::handlers::revoke::revoke;
 use crate::models::oidc_state::OidcState;
@@ -74,7 +74,14 @@ async fn main() -> AppResult<()> {
         .mount("/", routes![health, get_crl])
         .mount(
             "/api",
-            routes![register_agent, revoke, get_revocations, get_active_ledger],
+            routes![
+                register_agent,
+                revoke,
+                get_revocations,
+                get_all_ledger,
+                get_active_ledger,
+                get_revoked_ledger
+            ],
         )
         .launch()
         .await

--- a/crates/wazuh-cert-oauth2-server/src/main.rs
+++ b/crates/wazuh-cert-oauth2-server/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use crate::handlers::crl::{get_crl, get_revocations};
 use crate::handlers::health::health;
+use crate::handlers::ledger::get_active_ledger;
 use crate::handlers::register_agent::register_agent;
 use crate::handlers::revoke::revoke;
 use crate::models::oidc_state::OidcState;
@@ -71,7 +72,10 @@ async fn main() -> AppResult<()> {
         .manage(Ledger::new(ledger_path.into()).await?)
         .manage(CrlState::new(crl_path.into()).await?)
         .mount("/", routes![health, get_crl])
-        .mount("/api", routes![register_agent, revoke, get_revocations])
+        .mount(
+            "/api",
+            routes![register_agent, revoke, get_revocations, get_active_ledger],
+        )
         .launch()
         .await
         .map_err(|e| AppError::RocketError(Box::new(e)))?;

--- a/crates/wazuh-cert-oauth2-server/src/shared/certs/sign.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/certs/sign.rs
@@ -6,7 +6,9 @@ use wazuh_cert_oauth2_model::models::signed_cert_response::SignedCertResponse;
 
 use crate::handlers::middle::JwtToken;
 use crate::models::ca_config::CaProvider;
+use crate::shared::crl::CrlState;
 use crate::shared::ledger::Ledger;
+use tracing::info;
 
 use super::{
     append_client_eku, append_core_extensions, append_crl_dp, append_key_usage,
@@ -38,6 +40,7 @@ pub async fn sign_csr(
     JwtToken { claims }: JwtToken,
     ca: &CaProvider,
     ledger: &Ledger,
+    crl: &CrlState,
 ) -> AppResult<SignedCertResponse> {
     let csr = X509Req::from_pem(dto.csr_pem.as_bytes())?;
     let csr_pubkey = csr
@@ -50,11 +53,18 @@ pub async fn sign_csr(
 
     let is_admin = claims.is_admin();
 
-    // Policy Enforcement: single cert per user unless admin
-    if !is_admin {
-        ledger
+    if is_admin {
+        info!(sub = %claims.sub, "admin user; skipping single-cert policy");
+    } else {
+        let did_revoke = ledger
             .check_and_revoke_active(claims.sub.clone(), dto.overwrite == Some(true))
             .await?;
+        if did_revoke {
+            // Rebuild the CRL immediately
+            let (ca_cert, ca_key) = ca.get().await?;
+            let revs = ledger.revoked_as_revocations().await;
+            crl.request_rebuild(ca_cert, ca_key, revs).await?;
+        }
     }
 
     enforce_key_policy(&csr_pubkey)?;

--- a/crates/wazuh-cert-oauth2-server/src/shared/certs/sign.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/certs/sign.rs
@@ -48,6 +48,15 @@ pub async fn sign_csr(
         return Err(AppError::CsrVerificationFailed);
     }
 
+    let is_admin = claims.is_admin();
+
+    // Policy Enforcement: single cert per user unless admin
+    if !is_admin {
+        ledger
+            .check_and_revoke_active(claims.sub.clone(), dto.overwrite == Some(true))
+            .await?;
+    }
+
     enforce_key_policy(&csr_pubkey)?;
     let (ca_cert, ca_key) = ca.get().await?;
     let cert = sign_csr_with_ca(

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/commands.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/commands.rs
@@ -21,6 +21,6 @@ pub(super) enum Command {
         subject: String,
         overwrite: bool,
         revoked_at_unix: u64,
-        respond_to: tokio::sync::oneshot::Sender<AppResult<()>>,
+        respond_to: tokio::sync::oneshot::Sender<AppResult<bool>>,
     },
 }

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/commands.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/commands.rs
@@ -17,4 +17,10 @@ pub(super) enum Command {
         revoked_at_unix: u64,
         respond_to: tokio::sync::oneshot::Sender<AppResult<()>>,
     },
+    CheckAndRevokeActive {
+        subject: String,
+        overwrite: bool,
+        revoked_at_unix: u64,
+        respond_to: tokio::sync::oneshot::Sender<AppResult<()>>,
+    },
 }

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/mod.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/mod.rs
@@ -7,11 +7,10 @@ mod commands;
 mod csv;
 mod csv_utils;
 mod loader;
-mod types;
 mod worker;
 
-pub use types::LedgerEntry;
 use wazuh_cert_oauth2_model::models::errors::{AppError, AppResult};
+pub use wazuh_cert_oauth2_model::models::ledger_entry::LedgerEntry;
 
 #[derive(Clone)]
 pub struct Ledger {
@@ -88,6 +87,38 @@ impl Ledger {
             .await
             .iter()
             .filter(|e| e.subject == subject)
+            .cloned()
+            .collect()
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn check_and_revoke_active(&self, subject: String, overwrite: bool) -> AppResult<()> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(worker::Command::CheckAndRevokeActive {
+                subject,
+                overwrite,
+                revoked_at_unix: now,
+                respond_to: tx,
+            })
+            .await
+            .map_err(|e| AppError::UpstreamError(format!("ledger writer dropped: {}", e)))?;
+        rx.await
+            .map_err(|e| AppError::UpstreamError(format!("ledger writer closed: {}", e)))??;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn find_active(&self) -> Vec<LedgerEntry> {
+        self.inner
+            .read()
+            .await
+            .iter()
+            .filter(|e| !e.revoked)
             .cloned()
             .collect()
     }

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/mod.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/mod.rs
@@ -92,7 +92,11 @@ impl Ledger {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn check_and_revoke_active(&self, subject: String, overwrite: bool) -> AppResult<()> {
+    pub async fn check_and_revoke_active(
+        &self,
+        subject: String,
+        overwrite: bool,
+    ) -> AppResult<bool> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -108,8 +112,7 @@ impl Ledger {
             .await
             .map_err(|e| AppError::UpstreamError(format!("ledger writer dropped: {}", e)))?;
         rx.await
-            .map_err(|e| AppError::UpstreamError(format!("ledger writer closed: {}", e)))??;
-        Ok(())
+            .map_err(|e| AppError::UpstreamError(format!("ledger writer closed: {}", e)))?
     }
 
     #[tracing::instrument(skip(self))]
@@ -121,6 +124,22 @@ impl Ledger {
             .filter(|e| !e.revoked)
             .cloned()
             .collect()
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn find_revoked(&self) -> Vec<LedgerEntry> {
+        self.inner
+            .read()
+            .await
+            .iter()
+            .filter(|e| e.revoked)
+            .cloned()
+            .collect()
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn find_all(&self) -> Vec<LedgerEntry> {
+        self.inner.read().await.clone()
     }
 
     #[tracing::instrument(skip(self))]
@@ -216,6 +235,73 @@ mod tests {
         assert_eq!(revocations.len(), 1);
         assert_eq!(revocations[0].serial_hex, "UNKNOWN01");
         assert_eq!(revocations[0].reason.as_deref(), Some("preemptive"));
+
+        let _ = fs::remove_dir_all(parent).await;
+    }
+
+    #[tokio::test]
+    async fn check_and_revoke_active_returns_true_when_cert_was_revoked() {
+        let path = unique_ledger_path();
+        let parent = path.parent().expect("path should have parent");
+        fs::create_dir_all(parent)
+            .await
+            .expect("temp dir should exist");
+
+        let ledger = Ledger::new(path.clone())
+            .await
+            .expect("ledger should initialize");
+        ledger
+            .record_issued(
+                "user-a".to_string(),
+                "CERT01".to_string(),
+                Some("https://issuer/realms/dev".to_string()),
+                Some("dev".to_string()),
+            )
+            .await
+            .expect("record_issued should succeed");
+
+        // overwrite=true — should revoke the existing cert and return true
+        let did_revoke = ledger
+            .check_and_revoke_active("user-a".to_string(), true)
+            .await
+            .expect("check_and_revoke_active should succeed");
+        assert!(did_revoke, "expected true when an active cert was revoked");
+
+        let active = ledger.find_active().await;
+        assert!(
+            active.is_empty(),
+            "no active certs should remain after auto-rotate"
+        );
+
+        let revocations = ledger.revoked_as_revocations().await;
+        assert_eq!(revocations.len(), 1);
+        assert_eq!(revocations[0].serial_hex, "CERT01");
+        assert_eq!(
+            revocations[0].reason.as_deref(),
+            Some("auto-rotate (one cert per user)")
+        );
+
+        let _ = fs::remove_dir_all(parent).await;
+    }
+
+    #[tokio::test]
+    async fn check_and_revoke_active_returns_false_when_no_active_cert() {
+        let path = unique_ledger_path();
+        let parent = path.parent().expect("path should have parent");
+        fs::create_dir_all(parent)
+            .await
+            .expect("temp dir should exist");
+
+        let ledger = Ledger::new(path.clone())
+            .await
+            .expect("ledger should initialize");
+
+        // No certs at all — should return false, not error
+        let did_revoke = ledger
+            .check_and_revoke_active("user-b".to_string(), true)
+            .await
+            .expect("check_and_revoke_active should succeed even with no certs");
+        assert!(!did_revoke);
 
         let _ = fs::remove_dir_all(parent).await;
     }

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/worker.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/worker.rs
@@ -54,10 +54,27 @@ async fn ledger_worker(
                     apply_mark_revoked(&inner, &path, serial_hex, reason, revoked_at_unix).await;
                 let _ = respond_to.send(res);
             }
+            Command::CheckAndRevokeActive {
+                subject,
+                overwrite,
+                revoked_at_unix,
+                respond_to,
+            } => {
+                let res = apply_check_and_revoke_active(
+                    &inner,
+                    &path,
+                    &subject,
+                    overwrite,
+                    revoked_at_unix,
+                )
+                .await;
+                let _ = respond_to.send(res);
+            }
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_record_issued(
     inner: &Arc<RwLock<Vec<LedgerEntry>>>,
     path: &PathBuf,
@@ -97,9 +114,11 @@ async fn apply_mark_revoked(
             .rev()
             .find(|e| e.serial_hex.eq_ignore_ascii_case(&serial_hex))
         {
-            entry.revoked = true;
-            entry.revoked_at_unix = Some(revoked_at_unix);
-            entry.reason = reason.clone();
+            if !entry.revoked {
+                entry.revoked = true;
+                entry.revoked_at_unix = Some(revoked_at_unix);
+                entry.reason = reason.clone();
+            }
         } else {
             guard.push(LedgerEntry {
                 subject: String::new(),
@@ -113,5 +132,48 @@ async fn apply_mark_revoked(
             });
         }
     }
+    persist_csv(path, inner).await
+}
+
+async fn apply_check_and_revoke_active(
+    inner: &Arc<RwLock<Vec<LedgerEntry>>>,
+    path: &PathBuf,
+    subject: &str,
+    overwrite: bool,
+    revoked_at_unix: u64,
+) -> AppResult<()> {
+    use wazuh_cert_oauth2_model::models::errors::AppError;
+
+    let active_serials: Vec<String> = {
+        let guard = inner.read().await;
+        guard
+            .iter()
+            .filter(|e| e.subject == subject && !e.revoked)
+            .map(|e| e.serial_hex.clone())
+            .collect()
+    };
+
+    if active_serials.is_empty() {
+        return Ok(());
+    }
+
+    if !overwrite {
+        return Err(AppError::Conflict(
+            "User already has an active certificate. Use the --overwrite flag to re-enroll and replace it.".to_string(),
+        ));
+    }
+
+    {
+        let mut guard = inner.write().await;
+        for entry in guard
+            .iter_mut()
+            .filter(|e| e.subject == subject && !e.revoked)
+        {
+            entry.revoked = true;
+            entry.revoked_at_unix = Some(revoked_at_unix);
+            entry.reason = Some("auto-rotate (one cert per user)".to_string());
+        }
+    }
+
     persist_csv(path, inner).await
 }

--- a/crates/wazuh-cert-oauth2-server/src/shared/ledger/worker.rs
+++ b/crates/wazuh-cert-oauth2-server/src/shared/ledger/worker.rs
@@ -60,7 +60,7 @@ async fn ledger_worker(
                 revoked_at_unix,
                 respond_to,
             } => {
-                let res = apply_check_and_revoke_active(
+                let res: AppResult<bool> = apply_check_and_revoke_active(
                     &inner,
                     &path,
                     &subject,
@@ -141,20 +141,15 @@ async fn apply_check_and_revoke_active(
     subject: &str,
     overwrite: bool,
     revoked_at_unix: u64,
-) -> AppResult<()> {
+) -> AppResult<bool> {
     use wazuh_cert_oauth2_model::models::errors::AppError;
 
-    let active_serials: Vec<String> = {
-        let guard = inner.read().await;
-        guard
-            .iter()
-            .filter(|e| e.subject == subject && !e.revoked)
-            .map(|e| e.serial_hex.clone())
-            .collect()
-    };
+    // Hold the write lock for the full check-and-mutate to avoid a TOCTOU gap.
+    let mut guard = inner.write().await;
 
-    if active_serials.is_empty() {
-        return Ok(());
+    let has_active = guard.iter().any(|e| e.subject == subject && !e.revoked);
+    if !has_active {
+        return Ok(false);
     }
 
     if !overwrite {
@@ -163,17 +158,17 @@ async fn apply_check_and_revoke_active(
         ));
     }
 
+    for entry in guard
+        .iter_mut()
+        .filter(|e| e.subject == subject && !e.revoked)
     {
-        let mut guard = inner.write().await;
-        for entry in guard
-            .iter_mut()
-            .filter(|e| e.subject == subject && !e.revoked)
-        {
-            entry.revoked = true;
-            entry.revoked_at_unix = Some(revoked_at_unix);
-            entry.reason = Some("auto-rotate (one cert per user)".to_string());
-        }
+        entry.revoked = true;
+        entry.revoked_at_unix = Some(revoked_at_unix);
+        entry.reason = Some("auto-rotate (one cert per user)".to_string());
     }
+    // Release the read+write lock before the async persist.
+    drop(guard);
 
-    persist_csv(path, inner).await
+    persist_csv(path, inner).await?;
+    Ok(true)
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/bootstrap.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/bootstrap.rs
@@ -3,6 +3,7 @@ use tracing::error;
 use wazuh_cert_oauth2_model::models::errors::{AppError, AppResult};
 use wazuh_cert_oauth2_model::services::http_client::HttpClient;
 
+use crate::handlers::enrollment::get_enrollment_report;
 use crate::handlers::health::health;
 use crate::handlers::webhook::send_webhook;
 use crate::opts::Opt;
@@ -29,6 +30,7 @@ pub fn build_state(opt: &Opt) -> AppResult<ProxyState> {
         opt.webhook_basic_password.clone(),
         opt.webhook_api_key.clone(),
         opt.webhook_bearer_token.clone(),
+        opt.keycloak_admin_base_url.clone(),
     )?;
     Ok(state)
 }
@@ -46,7 +48,7 @@ pub async fn launch_rocket(state: ProxyState) -> AppResult<()> {
     rocket::build()
         .manage(state)
         .mount("/", routes![health])
-        .mount("/api", routes![send_webhook])
+        .mount("/api", routes![send_webhook, get_enrollment_report])
         .launch()
         .await
         .map_err(|e| AppError::RocketError(Box::new(e)))?;

--- a/crates/wazuh-cert-oauth2-webhook/src/handlers/enrollment.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/handlers/enrollment.rs
@@ -1,0 +1,11 @@
+use crate::state::{EnrollmentReport, ProxyState};
+use rocket::State;
+use rocket::serde::json::Json;
+use wazuh_cert_oauth2_model::models::errors::AppResult;
+
+#[get("/enrollment/report")]
+#[tracing::instrument(skip(state))]
+pub async fn get_enrollment_report(state: &State<ProxyState>) -> AppResult<Json<EnrollmentReport>> {
+    let report = crate::state::generate_report(state).await?;
+    Ok(Json(report))
+}

--- a/crates/wazuh-cert-oauth2-webhook/src/handlers/mod.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod enrollment;
 pub mod health;
 pub mod webhook;
 pub mod webhook_util;

--- a/crates/wazuh-cert-oauth2-webhook/src/opts.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/opts.rs
@@ -61,4 +61,7 @@ pub struct Opt {
     pub webhook_api_key: Option<String>,
     #[arg(long, env = "WEBHOOK_BEARER_TOKEN")]
     pub webhook_bearer_token: Option<String>,
+
+    #[arg(long, env = "KEYCLOAK_ADMIN_BASE_URL")]
+    pub keycloak_admin_base_url: Option<String>,
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/audit.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/audit.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+use wazuh_cert_oauth2_model::models::errors::AppResult;
+use wazuh_cert_oauth2_model::models::ledger_entry::LedgerEntry;
+
+use super::ProxyState;
+use super::oauth::acquire_oauth_token;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeycloakUser {
+    pub id: String,
+    pub username: String,
+    pub email: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrollmentReport {
+    pub enabled_users: usize,
+    pub active_certs: usize,
+    pub gap_count: usize,
+    pub missing_users: Vec<String>,
+    pub generated_at_unix: u64,
+}
+
+pub async fn generate_report(state: &ProxyState) -> AppResult<EnrollmentReport> {
+    debug!("Generating enrollment report");
+
+    // 1. Fetch Users from Keycloak
+    let token = acquire_oauth_token(state).await?.ok_or_else(|| {
+        wazuh_cert_oauth2_model::models::errors::AppError::UpstreamError(
+            "OAuth2 not configured, cannot audit users".to_string(),
+        )
+    })?;
+
+    let admin_url = state.keycloak_admin_base_url.as_ref().ok_or_else(|| {
+        wazuh_cert_oauth2_model::models::errors::AppError::UpstreamError(
+            "KEYCLOAK_ADMIN_BASE_URL not configured. This is required for enrollment auditing."
+                .to_string(),
+        )
+    })?;
+
+    // Use a large max as a stopgap for non-trivial deployments.
+    // Real fix would involve cursor/offset pagination.
+    let users_url = format!("{}/users?max=5000", admin_url.trim_end_matches('/'));
+
+    debug!("Fetching users from Keycloak: {}", users_url);
+    let users: Vec<KeycloakUser> = state.http.fetch_json_auth(&users_url, &token).await?;
+
+    // 2. Fetch Active Certs from Server
+    let server_url = format!(
+        "{}/api/ledger/active",
+        state.server_base_url.trim_end_matches('/')
+    );
+    debug!("Fetching active certs from server: {}", server_url);
+    let certs: Vec<LedgerEntry> = state.http.fetch_json_auth(&server_url, &token).await?;
+
+    // 3. Correlate
+    // Note: This assumes the certificate subject field stores the Keycloak user UUID (u.id).
+    let enrolled_subs: std::collections::HashSet<String> =
+        certs.into_iter().map(|c| c.subject).collect();
+
+    if enrolled_subs.is_empty() && !users.is_empty() {
+        debug!(
+            "Correlation set is empty despite having users; verify that certificate subjects match Keycloak IDs"
+        );
+    }
+
+    let mut missing = Vec::new();
+    let mut enrolled_count = 0;
+
+    for u in users.into_iter().filter(|u| u.enabled) {
+        if enrolled_subs.contains(&u.id) {
+            enrolled_count += 1;
+        } else {
+            missing.push(u.username);
+        }
+    }
+
+    let report = EnrollmentReport {
+        enabled_users: enrolled_count + missing.len(),
+        active_certs: enrolled_count,
+        gap_count: missing.len(),
+        missing_users: missing,
+        generated_at_unix: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| {
+                wazuh_cert_oauth2_model::models::errors::AppError::UpstreamError(
+                    "System clock is before Unix epoch".to_string(),
+                )
+            })?
+            .as_secs(),
+    };
+
+    info!(
+        "Enrollment audit complete: {} enabled users, {} active certs, {} gap",
+        report.enabled_users, report.active_certs, report.gap_count
+    );
+
+    Ok(report)
+}

--- a/crates/wazuh-cert-oauth2-webhook/src/state/builder.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/builder.rs
@@ -28,6 +28,7 @@ impl ProxyState {
         webhook_basic_password: Option<String>,
         webhook_api_key: Option<String>,
         webhook_bearer_token: Option<String>,
+        keycloak_admin_base_url: Option<String>,
     ) -> AppResult<Self> {
         utils::ensure_spool_dir(&spool_dir);
         let oauth = oauth::build_oauth(
@@ -52,6 +53,7 @@ impl ProxyState {
             webhook_basic_password,
             webhook_api_key,
             webhook_bearer_token,
+            keycloak_admin_base_url,
             token_cache: Arc::new(RwLock::new(None)),
         })
     }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/core.rs
@@ -163,11 +163,12 @@ mod tests {
             None,
             None,
             None,
-            "test reason".to_string(),
+            "revoke".to_string(),
             webhook_basic_user,
             webhook_basic_password,
             webhook_api_key,
             webhook_bearer_token,
+            None,
         )
         .expect("state should build")
     }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/mod.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use wazuh_cert_oauth2_model::services::http_client::HttpClient;
 
+pub(crate) mod audit;
 mod builder;
 pub(crate) mod core;
 mod oauth;
 mod spool;
 mod utils;
 
+pub use audit::{EnrollmentReport, generate_report};
 pub use spool::spawn_spool_processor;
 
 #[derive(Clone)]
@@ -32,6 +34,7 @@ pub struct ProxyState {
     webhook_basic_password: Option<String>,
     webhook_api_key: Option<String>,
     webhook_bearer_token: Option<String>,
+    pub(crate) keycloak_admin_base_url: Option<String>,
 
     pub(crate) token_cache: Arc<RwLock<Option<oauth::CachedToken>>>,
 }

--- a/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
+++ b/crates/wazuh-cert-oauth2-webhook/src/state/spool.rs
@@ -179,6 +179,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .expect("state should build")
     }


### PR DESCRIPTION
## Summary
Enforces a single-certificate-per-user policy on the server, adds an `--overwrite` flag for re-enrollment, and introduces an enrollment audit report on the webhook.

## Related Issues
Closes #201 

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] CI/CD or tooling

## Changes Made
- Single cert policy: server blocks re-enrollment if the user already has an active certificate, unless `--overwrite` is passed or the user has the `wazuh_admin` realm role in Keycloak
- Atomic check-and-revoke: conflict check and revocation of existing certs happen in a single ledger worker command (`CheckAndRevokeActive`) to eliminate the TOCTOU race between concurrent requests
- `--overwrite` CLI flag added to the client (defaults to `false`)
- `overwrite` field added to `SignCsrRequest` with `#[serde(default)]` so older clients omitting the field don't get a 422
- Server handler now returns `AppError` directly instead of bare `Status`, so all error responses are JSON with the correct status code (fixes the HTML 409 response)
- `GET /api/ledger/active` added to the server — returns all non-revoked certificates (JWT required)
- `GET /api/enrollment/report` added to the webhook — cross-references Keycloak users against active certs to surface enrollment gaps
- Keycloak realm config updated to grant `view-users` to both `test-client` and `test-client-secret` service accounts
- `xdg-open` browser launch fixed to work without sudo on Linux

## Checklist
- [x] Code follows the project's style (`cargo fmt`)
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] All tests pass (`cargo test`)
- [ ] No new clippy warnings (`cargo clippy -- -D warnings`)
- [ ] Documentation updated if needed

## Security Considerations
- [x] Security impact reviewed

The `wazuh_admin` role bypass is intentional and sourced from the verified JWT `realm_access.roles` claim. The atomic ledger operation prevents a race condition where two concurrent requests for the same subject could both pass the active-cert check and each receive a certificate.

## Testing
- [x] Unit tests
- [x] Manual testing with `docker compose`